### PR TITLE
Devathon viii page (Update responsive)

### DIFF
--- a/src/pages/devathon-viii-edition/index.astro
+++ b/src/pages/devathon-viii-edition/index.astro
@@ -71,7 +71,7 @@ const { teams, judges, menthors } = devathonData;
                       Backend
                     </a>
                   </li>
-                  {isWinner ? (
+                  {isWinner && 
                     <li>
                       <img
                         src="/img/devathon-medal.png"
@@ -80,9 +80,7 @@ const { teams, judges, menthors } = devathonData;
                         id={id}
                       />
                     </li>
-                  ) : (
-                    ""
-                  )}
+                  }
                 </ul>
 
                 </div>
@@ -94,7 +92,7 @@ const { teams, judges, menthors } = devathonData;
     </section>
     <h1>Mentores de esta edición</h1>
     <section class="menthors-container">
-      <p>
+      <p >
         En esta edición, participaron desarrolladores Sr. de forma voluntaria
         con el rol de mentores para poder ayudar a los equipos con dudas y
         bloqueos técnicos, mi total agradecimiento y mención honorífica a los

--- a/src/pages/devathon-viii-edition/styles.css
+++ b/src/pages/devathon-viii-edition/styles.css
@@ -52,13 +52,8 @@ h1 {
 	border-radius: 1rem;
 }
 
-.team-detail-card > ul,
-.menthors-container > ul {
-	list-style: none;
-	margin: 10px 0;
-}
-
 .menthor-list {
+	padding-top: 3rem;
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(5rem, 1fr));
 	justify-items: center;
@@ -85,6 +80,7 @@ h1 {
 	align-items: center;
 	gap: 0.5rem;
 	text-wrap: pretty;
+	text-align: center;
 }
 
 .edition-main-section {

--- a/src/pages/devathon-viii-edition/styles.css
+++ b/src/pages/devathon-viii-edition/styles.css
@@ -75,7 +75,7 @@ h1 {
 .team-member-list {
 	padding: 1.5rem 0;
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(7rem, 1fr));
 	gap: 1.5625rem;
 }
 .team-member-item {
@@ -84,6 +84,7 @@ h1 {
 	flex-direction: column;
 	align-items: center;
 	gap: 0.5rem;
+	text-wrap: pretty;
 }
 
 .edition-main-section {


### PR DESCRIPTION
- Ajusté el ancho de `grid-template` de 9rem a 7rem para que los elementos `team-member-item` (cada participante) se adapten mejor al diseño responsive.
- Mejoré la presentación de los nombres de los participantes largos utilizando `text-wrap: pretty` y centrándolos.
- Añadí un `padding-top` a la lista de mentores, ya que estaba demasiado cerca de la descripción.
- Noté que para mostrar el logo del ganador se utiliza un `ternario`, pero se podría simplificar usando `&&`, lo que mejora la legibilidad.

## Ahora cada participante encaja mejor y si el nombre es muy largo se adapta 
![image](https://github.com/user-attachments/assets/8ad30821-6b93-4b60-90ec-c070a164a248)

## Padding top en la lista de los mentores 
![image](https://github.com/user-attachments/assets/e6ce1d10-4647-4d64-a0f3-41717458e6e5)

## Cambio del ternario al && 
![image](https://github.com/user-attachments/assets/636dc9ac-470e-48bd-8f90-1db77e433c7a)
![image](https://github.com/user-attachments/assets/4b558b40-e4ac-4ab7-8b04-8cd110d15841)


