### PR TITLE
Fix: hide popover to prevent flashing on transition

### DIFF
--- a/src/components/astro/NetworkList/styles.css
+++ b/src/components/astro/NetworkList/styles.css
@@ -55,6 +55,7 @@
   align-items: center;
   gap: 4rem;
   overflow: hidden;
+  visibility: hidden;
 }
 
 [popover] p {
@@ -74,6 +75,7 @@
 
 [popover]:popover-open {
   translate: 25dvw 30dvh;
+  visibility: visible;
 }
 
 [popover]::backdrop {


### PR DESCRIPTION
This PR adds a hidden visibility to the networkList popover to prevent flashing between transitions.

# Changes

- Adds hidden visibility by default to the onlyfans popover

# Examples

<details>
<summary>Previus (with flashing)</summary>

![previous](https://github.com/user-attachments/assets/134aece4-278e-4992-ac18-86b99bb4c432)

</details>


<details>
<summary>New (without flashing)</summary>

![new](https://github.com/user-attachments/assets/1c6e6b98-0a45-4770-8f5a-e0a490ea32f4)

</details>