### PR TITLE
feat(list): adds item "VIII edición" to the list

### DIFF
--- a/.astro/settings.json
+++ b/.astro/settings.json
@@ -1,5 +1,5 @@
 {
 	"_variables": {
-		"lastUpdateCheck": 1732276891601
+		"lastUpdateCheck": 1735327703910
 	}
 }

--- a/src/components/astro/DevathonInfo/index.astro
+++ b/src/components/astro/DevathonInfo/index.astro
@@ -31,6 +31,7 @@ const {devathon} = Astro.props;
                                                 <li><a href="/devathon-v-edition">✅ V edición</a></li>
                                                 <li><a href="/devathon-vi-edition">✅ VI edición</a></li>
                                                 <li><a href="/devathon-vii-edition">✅ VII edición</a></li>
+                                                <li><a href="/devathon-viii-edition">✅ VIII edición</a></li>
                                             </ul>
                                         </div>
                                     : ""}


### PR DESCRIPTION
I noticed there's no link for the VIII edition of the Devathon yet. So I've included.

It's my first pull request against a repository that I don't own, so if I should have done it some other way (like do it against another branch), please, let me know.

Thanks, Pedro.